### PR TITLE
Bump protocol version to 70015 and actually use it

### DIFF
--- a/bitcoin-submittx
+++ b/bitcoin-submittx
@@ -25,7 +25,7 @@ from bitcoin.messages import msg_version, msg_inv, msg_ping, msg_verack, msg_pon
 from bitcoin.net import CInv
 
 MIN_PROTO_VERSION = 60001 # Must support BIP0031 (ping/pong)
-PROTO_VERSION = 60001 # Supports BIP0031
+PROTO_VERSION = 70015 # Supports BIP0031
 MY_SUBVERSION = "/pynode:0.0.1/"
 
 A = None
@@ -162,7 +162,7 @@ class NodeConn(threading.Thread):
                 return
 
         # stuff version msg into sendbuf
-        vt = msg_version()
+        vt = msg_version(PROTO_VERSION)
         vt.nServices = 0
         if self.dst[0].endswith('.onion'):
             vt.addrTo.ip = '0.0.0.0' # XXX encode onion into IP like bitcoind does


### PR DESCRIPTION
Bumps the protocol version to the most recent version.

Also use that version when sending a version message.