### PR TITLE
replace deprecated `Threading.isAlive()` method call

### DIFF
--- a/bitcoin-submittx
+++ b/bitcoin-submittx
@@ -339,7 +339,7 @@ def join_all(threads, timeout):
             if next_wait <= 0:
                 return
             t.join(next_wait)
-            alive += t.isAlive()
+            alive += t.is_alive()
 
 def parse_host_port(node, default_port):
     '''


### PR DESCRIPTION
The method has been deprecated since Python 3.8 and removed in Python 3.9, leading to the following error if ran with the latter:

```
Traceback (most recent call last):
 File "./bitcoin-submittx", line 463, in start
   join_all(threads, timeout)
 File "./bitcoin-submittx", line 342, in join _all
   alive += t.isAlive()
AttributeError: 'NodeConn' object has no attribute 'isAlive'
```

Using `Threading.is_alive()` fixes this; it should work with any Python version >= 3.5 as it's been there since, with the same functionality as `.isAlive()`.